### PR TITLE
remove whitespace after LockerGoga

### DIFF
--- a/enterprise-attack/malware/malware--5af7a825-2d9f-400d-931a-e00eb9e27f48.json
+++ b/enterprise-attack/malware/malware--5af7a825-2d9f-400d-931a-e00eb9e27f48.json
@@ -25,7 +25,7 @@
                 "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
             ],
             "x_mitre_aliases": [
-                "LockerGoga "
+                "LockerGoga"
             ],
             "modified": "2019-04-22T21:01:04.924Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
@@ -33,14 +33,14 @@
                 "Windows"
             ],
             "id": "malware--5af7a825-2d9f-400d-931a-e00eb9e27f48",
-            "name": "LockerGoga ",
+            "name": "LockerGoga",
             "created": "2019-04-16T19:00:49.435Z",
             "labels": [
                 "malware"
             ],
             "x_mitre_version": "1.0",
             "type": "malware",
-            "description": "[LockerGoga ](https://attack.mitre.org/software/S0372) is ransomware that has been tied to various attacks on European companies. It was first reported upon in January 2019.(Citation: Unit42 LockerGoga 2019)(Citation: CarbonBlack LockerGoga 2019)"
+            "description": "[LockerGoga](https://attack.mitre.org/software/S0372) is ransomware that has been tied to various attacks on European companies. It was first reported upon in January 2019.(Citation: Unit42 LockerGoga 2019)(Citation: CarbonBlack LockerGoga 2019)"
         }
     ]
 }

--- a/enterprise-attack/relationship/relationship--20904798-df45-48a6-8428-9e4fb913f6ae.json
+++ b/enterprise-attack/relationship/relationship--20904798-df45-48a6-8428-9e4fb913f6ae.json
@@ -8,7 +8,7 @@
             "object_marking_refs": [
                 "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
             ],
-            "description": "[LockerGoga ](https://attack.mitre.org/software/S0372) has been observed deleting its original launcher after execution.",
+            "description": "[LockerGoga](https://attack.mitre.org/software/S0372) has been observed deleting its original launcher after execution.",
             "relationship_type": "uses",
             "target_ref": "attack-pattern--56fca983-1cf1-4fd1-bda0-5e170a37ab59",
             "external_references": [

--- a/enterprise-attack/relationship/relationship--31daba72-fb27-45a9-9224-991032b605a8.json
+++ b/enterprise-attack/relationship/relationship--31daba72-fb27-45a9-9224-991032b605a8.json
@@ -8,7 +8,7 @@
             "object_marking_refs": [
                 "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
             ],
-            "description": "[LockerGoga ](https://attack.mitre.org/software/S0372) has encrypted files, including core Windows OS files, using RSA-OAEP MGF1 and then demanded Bitcoin be paid for the decryption key.",
+            "description": "[LockerGoga](https://attack.mitre.org/software/S0372) has encrypted files, including core Windows OS files, using RSA-OAEP MGF1 and then demanded Bitcoin be paid for the decryption key.",
             "relationship_type": "uses",
             "target_ref": "attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0",
             "external_references": [

--- a/enterprise-attack/relationship/relationship--d80bbf0c-2fb4-4272-a878-65662452d3ca.json
+++ b/enterprise-attack/relationship/relationship--d80bbf0c-2fb4-4272-a878-65662452d3ca.json
@@ -8,7 +8,7 @@
             "object_marking_refs": [
                 "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
             ],
-            "description": "[LockerGoga ](https://attack.mitre.org/software/S0372) has been observed moving around the victim network via SMB, indicating the actors behind this ransomware are manually copying files form computer to computer instead of self-propagating.",
+            "description": "[LockerGoga](https://attack.mitre.org/software/S0372) has been observed moving around the victim network via SMB, indicating the actors behind this ransomware are manually copying files form computer to computer instead of self-propagating.",
             "relationship_type": "uses",
             "target_ref": "attack-pattern--e6919abc-99f9-4c6c-95a5-14761e7b2add",
             "external_references": [


### PR DESCRIPTION
There is a whitespace after LockerGoga in some names/aliases/references, which most likely should be removed.