### PR TITLE
fix: error in T1168  technique url

### DIFF
--- a/enterprise-attack/course-of-action/course-of-action--c47a9b55-8f61-4b82-b833-1db6242c754e.json
+++ b/enterprise-attack/course-of-action/course-of-action--c47a9b55-8f61-4b82-b833-1db6242c754e.json
@@ -11,7 +11,7 @@
                 {
                     "external_id": "T1168",
                     "source_name": "mitre-attack",
-                    "url": "https://attack.mitre.org/mitigations/T1168"
+                    "url": "https://attack.mitre.org/techniques/T1168"
                 }
             ],
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",


### PR DESCRIPTION
The URL of technique T1168 pointed to the `mitigations` path and not the `techniques` one.
This PR is to correct this small error that appeared in the latest update of ATT&CK.
