### PR TITLE
Fix malware label not in the malware-label-ov vocabulary

### DIFF
--- a/enterprise-attack/malware/malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06.json
+++ b/enterprise-attack/malware/malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06.json
@@ -17,7 +17,8 @@
             ],
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "labels": [
-                "malware"
+                "remote-access-trojan",
+                "backdoor"
             ],
             "created": "2019-06-18T18:40:33.671Z",
             "modified": "2019-06-30T23:27:21.997Z",
@@ -34,7 +35,7 @@
                 {
                     "source_name": "Flashpoint FIN 7 March 2019",
                     "description": "Platt, J. and Reeves, J.. (2019, March). FIN7 Revisited: Inside Astra Panel and SQLRat Malware. Retrieved June 18, 2019.",
-                    "url": "https://www.flashpoint-intel.com/blog/fin7-revisited-inside-astra-panel-and-sqlrat-malware/ "
+                    "url": "https://www.flashpoint-intel.com/blog/fin7-revisited-inside-astra-panel-and-sqlrat-malware/"
                 }
             ]
         }


### PR DESCRIPTION
The "malware" label is not in the `malware-label-ov` vocabulary of STIX2. See http://docs.oasis-open.org/cti/stix/v2.0/cs01/part1-stix-core/stix-v2.0-cs01-part1-stix-core.html#_Toc496709302 

I also removed the ending sapce in the url report.

Before 
```console 
$ curl https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/malware/malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06.json 2>/dev/null |stix2_validator -v
================================================================================
[-] Results for: stdin
[X] STIX JSON: Invalid
    [!] Warning: malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06: {216} labels contains a value not in the malware-label-ov vocabulary.
    [!] Warning: malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06: {302} External reference 'mitre-attack' has a URL but no hash.
    [X] malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06: external_references[2].url: 'https://www.flashpoint-intel.com/blog/fin7-revisited-inside-astra-panel-and-sqlrat-malware/ ' does not match "^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\\/\\/((?:(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:]|%[0-9a-fA-F]{2})*))(\\3)@)?(?=((?:\\[?(?:::[a-fA-F0-9]+(?::[a-fA-F0-9]+)?|(?:[a-fA-F0-9]+:)+(?::[a-fA-F0-9]+)+|(?:[a-fA-F0-9]+:)+(?::|(?:[a-fA-F0-9]+:?)*))\\]?)|(?:[a-zA-Z0-9-._~!$&'()*+,;=]|%[0-9a-fA-F]{2})*))\\5(?::(?=(\\d*))\\6)?)(\\/(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/]|%[0-9a-fA-F]{2})*))\\8)?|(\\/?(?!\\/)(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/]|%[0-9a-fA-F]{2})*))\\10)?)(?:\\?(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/?]|%[0-9a-fA-F]{2})*))\\11)?(?:#(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/?]|%[0-9a-fA-F]{2})*))\\12)?$"

Failed validating 'pattern' in schema['allOf'][0]['properties']['external_references']['items']['properties']['url']:
    {'$schema': 'http://json-schema.org/draft-04/schema#',
     'description': 'Matches the elements of a URL using a regular '
                    'expression.',
     'id': '../common/url-regex.json',
     'pattern': "^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\\/\\/((?:(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:]|%[0-9a-fA-F]{2})*))(\\3)@)?(?=((?:\\[?(?:::[a-fA-F0-9]+(?::[a-fA-F0-9]+)?|(?:[a-fA-F0-9]+:)+(?::[a-fA-F0-9]+)+|(?:[a-fA-F0-9]+:)+(?::|(?:[a-fA-F0-9]+:?)*))\\]?)|(?:[a-zA-Z0-9-._~!$&'()*+,;=]|%[0-9a-fA-F]{2})*))\\5(?::(?=(\\d*))\\6)?)(\\/(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/]|%[0-9a-fA-F]{2})*))\\8)?|(\\/?(?!\\/)(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/]|%[0-9a-fA-F]{2})*))\\10)?)(?:\\?(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/?]|%[0-9a-fA-F]{2})*))\\11)?(?:#(?=((?:[a-zA-Z0-9-._~!$&'()*+,;=:@\\/?]|%[0-9a-fA-F]{2})*))\\12)?$",
     'title': 'url-regex',
     'type': 'string'}

On instance:
    'https://www.flashpoint-intel.com/blog/fin7-revisited-inside-astra-panel-and-sqlrat-malware/ '

```

After 
```console
$ cat malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06.json |stix2_validator -v
================================================================================
[-] Results for: stdin
[+] STIX JSON: Valid
    [!] Warning: malware--8fc6c9e7-a162-4ca4-a488-f1819e9a7b06: {302} External reference 'mitre-attack' has a URL but no hash.


```