### PR TITLE
update USAGE with snippet for getting techniques and sub-techniques

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -409,7 +409,7 @@ def get_techniques_or_subtechniques(src, include="both"):
 
 
 subtechniques = get_techniques_or_subtechniques(src, "subtechniques")
-subtechniques = remove_revoked_deprecated(techniques) # see https://github.com/mitre/cti/blob/master/USAGE.md#removing-revoked-and-deprecated-objects
+subtechniques = remove_revoked_deprecated(subtechniques) # see https://github.com/mitre/cti/blob/master/USAGE.md#removing-revoked-and-deprecated-objects
 ```
 
 ### Objects by content

--- a/USAGE.md
+++ b/USAGE.md
@@ -380,7 +380,7 @@ See [The ATT&CK data model](#The-ATTCK-Data-Model) for mappings of ATT&CK type t
 groups = src.query([ stix2.Filter("type", "=", "intrusion-set") ])
 ```
 
-#### Getting Techniques or Sub-Techniques
+#### Getting techniques or sub-techniques
 ATT&CK Techniques and sub-techniques are both represented as `attack-pattern` objects. Therefore further parsing is necessary to get specifically techniques or sub-techniques.
 
 ```python

--- a/USAGE.md
+++ b/USAGE.md
@@ -377,7 +377,39 @@ See [The ATT&CK data model](#The-ATTCK-Data-Model) for mappings of ATT&CK type t
 
 ```python
 # use the appropriate STIX type in the query according to the desired ATT&CK type
-techniques = src.query([ stix2.Filter("type", "=", "attack-pattern") ])
+groups = src.query([ stix2.Filter("type", "=", "intrusion-set") ])
+```
+
+#### Getting Techniques or Sub-Techniques
+ATT&CK Techniques and sub-techniques are both represented as `attack-pattern` objects. Therefore further parsing is necessary to get specifically techniques or sub-techniques.
+
+```python
+def get_techniques_or_subtechniques(src, include="both"):
+    """Filter Techniques or Sub-Techniques from ATT&CK Enterprise Domain.
+    include argument has three options: "techniques", "subtechniques", or "both"
+    depending on the intended behavior."""
+    if include == "techniques":
+        query_results = src.query([
+            stix2.Filter('type', '=', 'attack-pattern'),
+            stix2.Filter('x_mitre_is_subtechnique', '=', False)
+        ])
+    elif include == "subtechniques":
+        query_results = src.query([
+            stix2.Filter('type', '=', 'attack-pattern'),
+            stix2.Filter('x_mitre_is_subtechnique', '=', True)
+        ])
+    elif include == "both":
+        query_results = src.query([
+            stix2.Filter('type', '=', 'attack-pattern')
+        ])
+    else:
+        raise RuntimeError("Unknown option %s!" % include)
+
+    return query_results
+
+
+subtechniques = get_techniques_or_subtechniques(src, "subtechniques")
+subtechniques = remove_revoked_deprecated(techniques) # see https://github.com/mitre/cti/blob/master/USAGE.md#removing-revoked-and-deprecated-objects
 ```
 
 ### Objects by content


### PR DESCRIPTION
Changes to USAGE:
1. Added "Getting techniques and sub-techniques" section as recommended in #97.
2. Updated "Objects by type" to get groups instead of techniques, so that it's not duplicative of "Getting techniques and sub-techniques."