### PR TITLE
update USAGE to clarify importing procedures

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,7 +6,7 @@ This document describes how to query and manipulate ATT&CK data from either this
 - [Accessing ATT&CK data in python](#accessing-attck-data-in-python), which describes different methodologies that can be used to load the ATT&CK data into a script
 - [Python recipes](#Python-Recipes), which provides python3 examples of common ways to query the ATT&CK data once loaded
 
-The latter two sections on the programmatic use of ATT&CK heavily utilize the [stix2 python library](https://github.com/oasis-open/cti-python-stix2). Please refer to the [STIX2 Python API Documentation](https://stix2.readthedocs.io/en/latest/) for more information on how to work with STIX programmatically.
+The latter two sections on the programmatic use of ATT&CK heavily utilize the [stix2 python library](https://github.com/oasis-open/cti-python-stix2). Please refer to the [STIX2 Python API Documentation](https://stix2.readthedocs.io/en/latest/) for more information on how to work with STIX programmatically. See also the section on [Requirements and imports](#requirements-and-imports).
 
 This document describes how ATT&CK implements and extends the STIX format. To find out more about STIX, please see [the STIX 2.0 website](https://oasis-open.github.io/cti-documentation/stix/intro). 
 
@@ -188,6 +188,41 @@ implementing the DataStore API and can be used interchangeably with the recipes 
 
 This section utilizes the [stix2 python library](https://github.com/oasis-open/cti-python-stix2). Please refer to the [STIX2 Python API Documentation](https://stix2.readthedocs.io/en/latest/) for more information on how to work with STIX programmatically.
 
+## Requirements and imports
+Before installing requirements, we recommend setting up a virtual environment:
+1. Create virtual environment:
+    - macOS and Linux: `python3 -m venv env`
+    - Windows: `py -m venv env`
+2. Activate the virtual environment:
+    - macOS and Linux: `source env/bin/activate`
+    - Windows: `env/Scripts/activate.bat`
+
+### stix2
+[stix2 can be installed by following the instructions on their repository](https://github.com/oasis-open/cti-python-stix2#installation). Imports for the recipes in this repository can be done from the base package, for example:
+
+```python
+from stix2 import Filter
+```
+
+However, if you are aiming to extend the ATT&CK dataset with new objects or implement complex workflows, you may need to use the `v20` specifier for some imports. This ensures that the objects use the STIX 2.0 API instead of the STIX 2.1 API. For example:
+
+```python
+from stix2.v20 import AttackPattern
+```
+
+You can see a full list of the classes which have versioned imports [here](https://stix2.readthedocs.io/en/latest/api/stix2.v20.html).
+
+### taxii2client
+[taxii2-client can be installed by following the instructions on their repository](https://github.com/oasis-open/cti-taxii-client#installation). How taxii2client should be imported depends on what version you have installed. You can check your installed version using `pip3 show taxii2-client | grep Version`.
+- **If version >= 2.0.0**, you *must* use the `v20` import in order to avoid [HTTP 406](https://httpstatuses.com/406) responses when connecting to the ATT&CK TAXII server:
+    ```python
+    from taxii2client.v20 import Collection
+    ```
+- **If version < 2.0.0**, you *must not* use the `v20` import because it was introduced in version 2.0.0:
+    ```python
+    from taxii2client import Collection
+    ```
+
 ## Access local content
 Many users may opt to access the ATT&CK content via a local copy of the STIX data on this repo. This can be advantageous for several reasons:
 - Doesn't require internet access after the initial download
@@ -199,17 +234,17 @@ Each domain in this repo is formatted according to the [STIX2 FileSystem spec](h
 Therefore you can use a `FileSystemSource` to load a domain, for example to load the enterprise-attack domain:
 
 ```python
-import stix2
+from stix2 import FileSystemSource
 
-src = stix2.FileSystemSource('./cti/enterprise-attack')
+src = FileSystemSource('./cti/enterprise-attack')
 ```
 
 ### Access via bundle
 If you instead prefer to download just the domain bundle, e.g [enterprise-attack.json](/enterprise-attack/enterprise-attack.json), you can still load this using a MemoryStore:
 ```python
-import stix2
+from stix2 import MemoryStore
 
-src = stix2.MemoryStore()
+src = MemoryStore()
 src.load_from_file("enterprise-attack.json")
 ```
 
@@ -231,7 +266,7 @@ The following recipe demonstrates how to access the enterprise-attack data from 
 
 ```python
 from stix2 import TAXIICollectionSource
-from taxii2client import Collection
+from taxii2client.v20 import Collection # only specify v20 if your installed version is >= 2.0.0
 
 collections = {
     "enterprise_attack": "95ecc380-afe9-11e4-9b6c-751b66dd541e",
@@ -252,12 +287,12 @@ access data on a branch of the MITRE/CTI repo (the TAXII server only holds the m
 
 ```python
 import requests
-import stix2
+from stix2 import MemoryStore
 
 def get_data_from_branch(domain, branch="master"):
     """get the ATT&CK STIX data from MITRE/CTI. Domain should be 'enterprise-attack', 'mobile-attack' or 'pre-attack'. Branch should typically be master."""
     stix_json = requests.get(f"https://raw.githubusercontent.com/mitre/cti/{branch}/{domain}/{domain}.json").json()
-    return stix2.MemoryStore(stix_data=stix_json["objects"])
+    return MemoryStore(stix_data=stix_json["objects"])
 
 src = get_data_from_branch("enterprise-attack")
 ```
@@ -270,12 +305,12 @@ In addition to checking out the repo under the tag for a given version or downlo
 
 ```python
 import requests
-import stix2
+from stix2 import MemoryStore
 
 def get_data_from_version(domain, version):
     """get the ATT&CK STIX data for the given version from MITRE/CTI. Domain should be 'enterprise-attack', 'mobile-attack' or 'pre-attack'."""
     stix_json = requests.get(f"https://raw.githubusercontent.com/mitre/cti/ATT%26CK-v{version}/{domain}/{domain}.json").json()
-    return stix2.MemoryStore(stix_data=stix_json["objects"])
+    return MemoryStore(stix_data=stix_json["objects"])
 
 src = get_data_from_version("enterprise-attack", "5.2")
 ```
@@ -299,7 +334,9 @@ domains into a single DataStore. Use any of the methods above to acquire the ind
 a single CompositeDataSource:
 
 ```python
-src = stix2.CompositeDataSource()
+from stix2 import CompositeDataSource
+
+src = CompositeDataSource()
 src.add_data_sources([enterprise_attack_src, pre_attack_src, mobile_attack_src])
 ```
 
@@ -308,7 +345,7 @@ You can then use this CompositeDataSource just as you would the DataSource for a
 # Python recipes
 Below are example python recipes which can be used to work with ATT&CK data. They assume the existence of an object implementing the DataStore API. Any of the methods outlined in the [Accessing ATT&CK data in python](#accessing-ATTCK-Data-in-Python) section should provide an object implementing this API.
 
-This section utilizes the [stix2 python library](https://github.com/oasis-open/cti-python-stix2). Please refer to the [STIX2 Python API Documentation](https://stix2.readthedocs.io/en/latest/) for more information on how to work with STIX programmatically.
+This section utilizes the [stix2 python library](https://github.com/oasis-open/cti-python-stix2). Please refer to the [STIX2 Python API Documentation](https://stix2.readthedocs.io/en/latest/) for more information on how to work with STIX programmatically. See also the section on [Requirements and imports](#requirements-and-imports).
 
 ## Getting an object
 The recipes in this section address how to query the dataset for a single object.
@@ -324,15 +361,19 @@ g0075 = src.get("intrusion-set--f40eb8ce-2a74-4e56-89a1-227021410142")
 The following recipe can be used to retrieve an object according to its ATT&CK ID:
 
 ```python
-g0075 = src.query([ stix2.Filter("external_references.external_id", "=", "G0075") ])[0]
+from stix2 import Filter
+
+g0075 = src.query([ Filter("external_references.external_id", "=", "G0075") ])[0]
 ```
 
 Note: in prior versions of ATT&CK, mitigations had 1:1 relationships with techniques and shared their technique's ID. Therefore the above method does not work properly for techniques because technique ATTT&CK IDs are not truly unique. By specifying the STIX type you're looking for as `attack-pattern` you can avoid this issue. 
 
 ```python
+from stix2 import Filter
+
 t1134 = src.query([ 
-    stix2.Filter("external_references.external_id", "=", "T1134"), 
-    stix2.Filter("type", "=", "attack-pattern")
+    Filter("external_references.external_id", "=", "T1134"), 
+    Filter("type", "=", "attack-pattern")
 ])[0]
 ```
 
@@ -342,6 +383,8 @@ The old 1:1 mitigations causing this issue are deprecated, so you can also filte
 The following recipe retrieves an object according to its name:
 
 ```python
+from stix2 import Filter
+
 def get_technique_by_name(thesrc, name):
     filt = [
         Filter('type', '=', 'attack-pattern'),
@@ -356,6 +399,8 @@ get_technique_by_name(src, 'System Information Discovery')
 The following methodology can be used to find the group corresponding to a given alias:
 
 ```python
+from stix2 import Filter
+
 def get_group_by_alias(thesrc, alias):
     return thesrc.query([
         Filter('type', '=', 'intrusion-set'),
@@ -376,31 +421,35 @@ The recipes in this section address how to query the dataset for multiple object
 See [The ATT&CK data model](#The-ATTCK-Data-Model) for mappings of ATT&CK type to STIX type.
 
 ```python
+from stix2 import Filter
+
 # use the appropriate STIX type in the query according to the desired ATT&CK type
-groups = src.query([ stix2.Filter("type", "=", "intrusion-set") ])
+groups = src.query([ Filter("type", "=", "intrusion-set") ])
 ```
 
 #### Getting techniques or sub-techniques
 ATT&CK Techniques and sub-techniques are both represented as `attack-pattern` objects. Therefore further parsing is necessary to get specifically techniques or sub-techniques.
 
 ```python
+from stix2 import Filter
+
 def get_techniques_or_subtechniques(src, include="both"):
     """Filter Techniques or Sub-Techniques from ATT&CK Enterprise Domain.
     include argument has three options: "techniques", "subtechniques", or "both"
     depending on the intended behavior."""
     if include == "techniques":
         query_results = src.query([
-            stix2.Filter('type', '=', 'attack-pattern'),
-            stix2.Filter('x_mitre_is_subtechnique', '=', False)
+            Filter('type', '=', 'attack-pattern'),
+            Filter('x_mitre_is_subtechnique', '=', False)
         ])
     elif include == "subtechniques":
         query_results = src.query([
-            stix2.Filter('type', '=', 'attack-pattern'),
-            stix2.Filter('x_mitre_is_subtechnique', '=', True)
+            Filter('type', '=', 'attack-pattern'),
+            Filter('x_mitre_is_subtechnique', '=', True)
         ])
     elif include == "both":
         query_results = src.query([
-            stix2.Filter('type', '=', 'attack-pattern')
+            Filter('type', '=', 'attack-pattern')
         ])
     else:
         raise RuntimeError("Unknown option %s!" % include)
@@ -416,6 +465,8 @@ subtechniques = remove_revoked_deprecated(subtechniques) # see https://github.co
 Sometimes it may be useful to query objects by the content of their description:
 
 ```python
+from stix2 import Filter
+
 def get_techniques_by_content(thesrc, content):
     techniques = src.query([ Filter('type', '=', 'attack-pattern') ])
     return list(filter(lambda t: content.lower() in t.description.lower(), techniques))
@@ -430,6 +481,8 @@ Techniques are associated with one or more platforms. You can query the techniqu
 under a specific platform with the following code:
 
 ```python
+from stix2 import Filter
+
 def get_techniques_by_platform(thesrc, platform):
     return thesrc.query([
         Filter('type', '=', 'attack-pattern'),
@@ -445,6 +498,8 @@ Techniques are related to tactics by their kill_chain_phases property.
 The `phase_name` of each kill chain phase corresponds to the `x_mitre_shortname` of a tactic.
 
 ```python
+from stix2 import Filter
+
 def get_tactic_techniques(thesrc, tactic):
     techs =  thesrc.query([
         Filter('type', '=', 'attack-pattern'),
@@ -471,10 +526,12 @@ found within the `tactic_refs` property in a matrix. The order of the tactics in
 the ordering of the tactics in that matrix. The following recipe returns a structured list of tactics within each matrix of the input DataStore.
 
 ```python
+from stix2 import Filter
+
 def getTacticsByMatrix(thesrc):
     tactics = {}
     matrix = thesrc.query([
-        stix2.Filter('type', '=', 'x-mitre-matrix'),
+        Filter('type', '=', 'x-mitre-matrix'),
     ])
     
     for i in range(len(matrix)):
@@ -494,6 +551,8 @@ This code could be used within a larger function or script to alert when a new o
 has been added to the ATT&CK catalog. 
 
 ```python
+from stix2 import Filter
+
 def get_created_after(thesrc, timestamp):
     filt = [
         Filter('created', '>', timestamp)
@@ -674,6 +733,7 @@ The following recipe can be used to retrieve the techniques used by a group's so
 
 ```python
 from stix2.utils import get_type_from_id
+from stix2 import Filter
 
 def get_techniques_by_group_software(src, group_stix_id):
     # get the malware, tools that the group uses
@@ -709,6 +769,8 @@ longer maintained by ATT&CK.
 Revoked and deprecated objects can be removed quite easily:
 
 ```python
+from stix2 import Filter
+
 def remove_revoked_deprecated(stix_objects):
     """Remove any revoked or deprecated objects from queries made to the data source"""
     # Note we use .get() because the property may not be present in the JSON data. The default is False
@@ -720,7 +782,7 @@ def remove_revoked_deprecated(stix_objects):
         )
     )
 
-mitigations = src.query([ stix2.Filter("type", "=", "course-of-action") ])
+mitigations = src.query([ Filter("type", "=", "course-of-action") ])
 mitigations = remove_revoked_deprecated(mitigations)
 ```
 
@@ -729,11 +791,13 @@ mitigations = remove_revoked_deprecated(mitigations)
 When an object is replaced by another object, it is marked with the field `revoked` and a relationship of type `revoked-by` is created where the `source_ref` is the revoked object and the `target_ref` is the revoking object. This relationship can be followed to find the replacing object:
 
 ```python
+from stix2 import Filter
+
 def getRevokedBy(stix_id, thesrc):
     relations = thesrc.relationships(stix_id, 'revoked-by', source_only=True)
     revoked_by = thesrc.query([
-        stix2.Filter('id', 'in', [r.target_ref for r in relations]),
-        stix2.Filter('revoked', '=', False)
+        Filter('id', 'in', [r.target_ref for r in relations]),
+        Filter('revoked', '=', False)
     ])
     if revoked_by is not None:
         revoked_by = revoked_by[0]


### PR DESCRIPTION
### Changes

1. [Added a new section to USAGE](https://github.com/mitre/cti/blob/docs/usage-imports/USAGE.md#requirements-and-imports) describing best practices for importing required libraries. This includes:
    - Environment setup advice
    - Links to install sections in `stix2` and `taxii2client` documentation.
    - Note about using `v20` import for `stix2` library to ensure the user uses STIX 2.0 API.
    - Note about using `v20` import for `taxii2client` (depending on installed version) in order to avoid a 406 error.
2. Added imports to Python recipes where appropriate
3. Standardized importing style in Python snippets: there should no longer be any direct `import stix2` references, instead they are now formatted`from stix2 import ...`

@emmanvg, could you please review this addition to the USAGE document? Neither `taxii2client` nor `stix2` include much documentation about the intended usage of their `v20` imports, so I want to make sure the documentation I'm adding here is accurate (and I know you have contributed to both `taxii2client` and `stix2`).
