### PR TITLE
Add the ICS TAXII collection to USAGE

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -258,6 +258,19 @@ Users can access the ATT&CK data from the official ATT&CK TAXII server. In TAXII
 |:-------|:--------------|
 | `enterprise-attack` | `95ecc380-afe9-11e4-9b6c-751b66dd541e` |
 | `mobile-attack` | `2f669986-b40b-4423-b720-4396ca6a462b` |
+| `ics-attack` | `02c3ef24-9cd4-48f3-a99f-b74ce24f1d34` |
+
+You can also get a list of available collection from the server directly:
+
+```python
+from taxii2client.v20 import Server # only specify v20 if your installed version is >= 2.0.0
+
+server = Server("https://cti-taxii.mitre.org/taxii/")
+api_root = server.api_roots[0]
+# Print name and ID of all ATT&CK domains available as collections
+for collection in api_root.collections:
+    print(collection.title.ljust(20) + collection.id)
+```
 
 The following recipe demonstrates how to access the enterprise-attack data from the TAXII server.
 
@@ -267,7 +280,8 @@ from taxii2client.v20 import Collection # only specify v20 if your installed ver
 
 collections = {
     "enterprise_attack": "95ecc380-afe9-11e4-9b6c-751b66dd541e",
-    "mobile_attack": "2f669986-b40b-4423-b720-4396ca6a462b"
+    "mobile_attack": "2f669986-b40b-4423-b720-4396ca6a462b",
+    "ics-attack": "02c3ef24-9cd4-48f3-a99f-b74ce24f1d34"
 }
 
 collection = Collection(f"https://cti-taxii.mitre.org/stix/collections/{collections['enterprise_attack']}/")


### PR DESCRIPTION
Adds the TAXII collection for the `ics-attack` domain to USAGE documentation. Also adds a code snippet for looking up the collections on the server.