### PR TITLE
Removed duplicate attack-pattern objects

### DIFF
--- a/ics-attack/attack-pattern/attack-pattern--008b8f56-6107-48be-aa9f-746f927dbb61.json
+++ b/ics-attack/attack-pattern/attack-pattern--008b8f56-6107-48be-aa9f-746f927dbb61.json
@@ -45,7 +45,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--008b8f56-6107-48be-aa9f-746f927dbb61"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--063b5b92-5361-481a-9c3f-95492ed9a2d8.json
+++ b/ics-attack/attack-pattern/attack-pattern--063b5b92-5361-481a-9c3f-95492ed9a2d8.json
@@ -44,7 +44,6 @@
                 "Windows Registry"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--063b5b92-5361-481a-9c3f-95492ed9a2d8"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722.json
+++ b/ics-attack/attack-pattern/attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722.json
@@ -44,7 +44,6 @@
                 "Application logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--138979ba-0430-4de6-a128-2fc0b056ba36.json
+++ b/ics-attack/attack-pattern/attack-pattern--138979ba-0430-4de6-a128-2fc0b056ba36.json
@@ -45,7 +45,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--138979ba-0430-4de6-a128-2fc0b056ba36"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--19a71d1e-6334-4233-8260-b749cae37953.json
+++ b/ics-attack/attack-pattern/attack-pattern--19a71d1e-6334-4233-8260-b749cae37953.json
@@ -40,7 +40,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--19a71d1e-6334-4233-8260-b749cae37953"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1.json
+++ b/ics-attack/attack-pattern/attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1.json
@@ -29,7 +29,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--1b22b676-9347-4c55-9a35-ef0dc653db5b.json
+++ b/ics-attack/attack-pattern/attack-pattern--1b22b676-9347-4c55-9a35-ef0dc653db5b.json
@@ -63,7 +63,6 @@
                 "Sequential Event Recorder"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1b22b676-9347-4c55-9a35-ef0dc653db5b"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--1c478716-71d9-46a4-9a53-fa5d576adb60.json
+++ b/ics-attack/attack-pattern/attack-pattern--1c478716-71d9-46a4-9a53-fa5d576adb60.json
@@ -37,7 +37,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1c478716-71d9-46a4-9a53-fa5d576adb60"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--23270e54-1d68-4c3b-b763-b25607bcef80.json
+++ b/ics-attack/attack-pattern/attack-pattern--23270e54-1d68-4c3b-b763-b25607bcef80.json
@@ -37,7 +37,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--23270e54-1d68-4c3b-b763-b25607bcef80"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--24a9253e-8948-4c98-b751-8e2aee53127c.json
+++ b/ics-attack/attack-pattern/attack-pattern--24a9253e-8948-4c98-b751-8e2aee53127c.json
@@ -33,20 +33,6 @@
             ],
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-            "x_mitre_platforms": [
-                "Windows Server 2003",
-                "Windows Server 2008",
-                "Windows Server 2012",
-                "Windows XP",
-                "Windows 7",
-                "Windows 8",
-                "Windows Server 2003 R2",
-                "Windows Server 2008 R2",
-                "Windows Server 2012 R2",
-                "Windows Vista",
-                "Windows 8.1",
-                "Linux"
-            ],
             "x_mitre_data_sources": [
                 "Process monitoring",
                 "Process command-line parameters",
@@ -54,7 +40,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--24a9253e-8948-4c98-b751-8e2aee53127c"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--25852363-5968-4673-b81d-341d5ed90bd1.json
+++ b/ics-attack/attack-pattern/attack-pattern--25852363-5968-4673-b81d-341d5ed90bd1.json
@@ -45,7 +45,6 @@
                 "Jos Wetzels - Midnight Blue"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--25852363-5968-4673-b81d-341d5ed90bd1"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9.json
+++ b/ics-attack/attack-pattern/attack-pattern--25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9.json
@@ -39,21 +39,6 @@
             ],
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-            "x_mitre_platforms": [
-                "Linux",
-                "SCADA/ICS device",
-                "Windows 7",
-                "Windows 8",
-                "Windows 8.1",
-                "Windows Server 2003",
-                "Windows Server 2003 R2",
-                "Windows Server 2008",
-                "Windows Server 2008 R2",
-                "Windows Server 2012",
-                "Windows Server 2012 R2",
-                "Windows Vista",
-                "Windows XP"
-            ],
             "x_mitre_data_sources": [
                 "Sequential event recorder",
                 "Alarm history",
@@ -61,7 +46,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2736b752-4ec5-4421-a230-8977dea7649c.json
+++ b/ics-attack/attack-pattern/attack-pattern--2736b752-4ec5-4421-a230-8977dea7649c.json
@@ -46,7 +46,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2736b752-4ec5-4421-a230-8977dea7649c"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2877063e-1851-48d2-bcc6-bc1d2733157e.json
+++ b/ics-attack/attack-pattern/attack-pattern--2877063e-1851-48d2-bcc6-bc1d2733157e.json
@@ -67,7 +67,6 @@
                 "Scott Dougherty"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2877063e-1851-48d2-bcc6-bc1d2733157e"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601.json
+++ b/ics-attack/attack-pattern/attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601.json
@@ -34,21 +34,6 @@
             ],
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-            "x_mitre_platforms": [
-                "Linux",
-                "SCADA/ICS device",
-                "Windows 7",
-                "Windows 8",
-                "Windows 8.1",
-                "Windows Server 2003",
-                "Windows Server 2003 R2",
-                "Windows Server 2008",
-                "Windows Server 2008 R2",
-                "Windows Server 2012",
-                "Windows Server 2012 R2",
-                "Windows Vista",
-                "Windows XP"
-            ],
             "x_mitre_data_sources": [
                 "Alarm history",
                 "Sequential event recorder",
@@ -56,7 +41,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2900bbd8-308a-4274-b074-5b8bde8347bc.json
+++ b/ics-attack/attack-pattern/attack-pattern--2900bbd8-308a-4274-b074-5b8bde8347bc.json
@@ -51,7 +51,6 @@
                 "Jos Wetzels - Midnight Blue"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2900bbd8-308a-4274-b074-5b8bde8347bc"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a.json
+++ b/ics-attack/attack-pattern/attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a.json
@@ -34,7 +34,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2d0d40ad-22fa-4cc8-b264-072557e1364b.json
+++ b/ics-attack/attack-pattern/attack-pattern--2d0d40ad-22fa-4cc8-b264-072557e1364b.json
@@ -44,7 +44,6 @@
                 "Administrator"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2d0d40ad-22fa-4cc8-b264-072557e1364b"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--2dc2b567-8821-49f9-9045-8740f3d0b958.json
+++ b/ics-attack/attack-pattern/attack-pattern--2dc2b567-8821-49f9-9045-8740f3d0b958.json
@@ -35,7 +35,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2dc2b567-8821-49f9-9045-8740f3d0b958"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--3067b85e-271e-4bc5-81ad-ab1a81d411e3.json
+++ b/ics-attack/attack-pattern/attack-pattern--3067b85e-271e-4bc5-81ad-ab1a81d411e3.json
@@ -37,7 +37,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3067b85e-271e-4bc5-81ad-ab1a81d411e3"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--32632a95-6856-47b9-9ab7-fea5cd7dce00.json
+++ b/ics-attack/attack-pattern/attack-pattern--32632a95-6856-47b9-9ab7-fea5cd7dce00.json
@@ -40,7 +40,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--32632a95-6856-47b9-9ab7-fea5cd7dce00"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--3405891b-16aa-4bd7-bd7c-733501f9b20f.json
+++ b/ics-attack/attack-pattern/attack-pattern--3405891b-16aa-4bd7-bd7c-733501f9b20f.json
@@ -39,7 +39,6 @@
                 "Third-party application logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3405891b-16aa-4bd7-bd7c-733501f9b20f"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--36e9f5bc-ac13-4da4-a2f4-01f4877d9004.json
+++ b/ics-attack/attack-pattern/attack-pattern--36e9f5bc-ac13-4da4-a2f4-01f4877d9004.json
@@ -39,7 +39,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--36e9f5bc-ac13-4da4-a2f4-01f4877d9004"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--38213338-1aab-479d-949b-c81b66ccca5c.json
+++ b/ics-attack/attack-pattern/attack-pattern--38213338-1aab-479d-949b-c81b66ccca5c.json
@@ -41,7 +41,6 @@
                 "Host network interfaces"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--38213338-1aab-479d-949b-c81b66ccca5c"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9.json
+++ b/ics-attack/attack-pattern/attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9.json
@@ -42,7 +42,6 @@
                 "Controller program"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--3de230d4-3e42-4041-b089-17e1128feded.json
+++ b/ics-attack/attack-pattern/attack-pattern--3de230d4-3e42-4041-b089-17e1128feded.json
@@ -37,7 +37,6 @@
                 "Process command-line parameters"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3de230d4-3e42-4041-b089-17e1128feded"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--3f1f4ccb-9be2-4ff8-8f69-dd972221169b.json
+++ b/ics-attack/attack-pattern/attack-pattern--3f1f4ccb-9be2-4ff8-8f69-dd972221169b.json
@@ -47,7 +47,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3f1f4ccb-9be2-4ff8-8f69-dd972221169b"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--40b300ba-f553-48bf-862e-9471b220d455.json
+++ b/ics-attack/attack-pattern/attack-pattern--40b300ba-f553-48bf-862e-9471b220d455.json
@@ -52,7 +52,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--40b300ba-f553-48bf-862e-9471b220d455"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--493832d9-cea6-4b63-abe7-9a65a6473675.json
+++ b/ics-attack/attack-pattern/attack-pattern--493832d9-cea6-4b63-abe7-9a65a6473675.json
@@ -36,20 +36,6 @@
             ],
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-            "x_mitre_platforms": [
-                "Windows Server 2003",
-                "Windows Server 2008",
-                "Windows Server 2012",
-                "Windows XP",
-                "Windows 7",
-                "Windows 8",
-                "Windows Server 2003 R2",
-                "Windows Server 2008 R2",
-                "Windows Server 2012 R2",
-                "Windows Vista",
-                "Windows 8.1",
-                "Linux"
-            ],
             "x_mitre_data_sources": [
                 "File monitoring",
                 "Process command-line parameters",
@@ -59,7 +45,6 @@
                 "Matan Dobrushin - Otorio"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--493832d9-cea6-4b63-abe7-9a65a6473675"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--4c2e1408-9d68-4187-8e6b-a77bc52700ec.json
+++ b/ics-attack/attack-pattern/attack-pattern--4c2e1408-9d68-4187-8e6b-a77bc52700ec.json
@@ -45,7 +45,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--4c2e1408-9d68-4187-8e6b-a77bc52700ec"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--50d3222f-7550-4a3c-94e1-78cb6c81d064.json
+++ b/ics-attack/attack-pattern/attack-pattern--50d3222f-7550-4a3c-94e1-78cb6c81d064.json
@@ -40,7 +40,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--50d3222f-7550-4a3c-94e1-78cb6c81d064"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--539d0484-fe95-485a-b654-86991c0d0d00.json
+++ b/ics-attack/attack-pattern/attack-pattern--539d0484-fe95-485a-b654-86991c0d0d00.json
@@ -34,7 +34,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--539d0484-fe95-485a-b654-86991c0d0d00"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--53a26eee-1080-4d17-9762-2027d5a1b805.json
+++ b/ics-attack/attack-pattern/attack-pattern--53a26eee-1080-4d17-9762-2027d5a1b805.json
@@ -38,7 +38,6 @@
                 "Windows event logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--53a26eee-1080-4d17-9762-2027d5a1b805"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--53a48c74-0025-45f4-b04a-baa853df8204.json
+++ b/ics-attack/attack-pattern/attack-pattern--53a48c74-0025-45f4-b04a-baa853df8204.json
@@ -38,7 +38,6 @@
                 "Controller program"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--53a48c74-0025-45f4-b04a-baa853df8204"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--56ddc820-6cfb-407f-850b-52c035d123ac.json
+++ b/ics-attack/attack-pattern/attack-pattern--56ddc820-6cfb-407f-850b-52c035d123ac.json
@@ -43,7 +43,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--56ddc820-6cfb-407f-850b-52c035d123ac"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--5a2610f6-9fff-41e1-bc27-575ca20383d4.json
+++ b/ics-attack/attack-pattern/attack-pattern--5a2610f6-9fff-41e1-bc27-575ca20383d4.json
@@ -35,7 +35,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5a2610f6-9fff-41e1-bc27-575ca20383d4"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--5e0f75da-e108-4688-a6de-a4f07cc2cbe3.json
+++ b/ics-attack/attack-pattern/attack-pattern--5e0f75da-e108-4688-a6de-a4f07cc2cbe3.json
@@ -45,7 +45,6 @@
                 "Digital signatures"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5e0f75da-e108-4688-a6de-a4f07cc2cbe3"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--5f3da2f3-91c8-4d8b-a02f-bf43a11def55.json
+++ b/ics-attack/attack-pattern/attack-pattern--5f3da2f3-91c8-4d8b-a02f-bf43a11def55.json
@@ -35,7 +35,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5f3da2f3-91c8-4d8b-a02f-bf43a11def55"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--5fa00fdd-4a55-4191-94a0-564181d7fec2.json
+++ b/ics-attack/attack-pattern/attack-pattern--5fa00fdd-4a55-4191-94a0-564181d7fec2.json
@@ -63,7 +63,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5fa00fdd-4a55-4191-94a0-564181d7fec2"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--63b6942d-8359-4506-bfb3-cf87aa8120ee.json
+++ b/ics-attack/attack-pattern/attack-pattern--63b6942d-8359-4506-bfb3-cf87aa8120ee.json
@@ -29,7 +29,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--63b6942d-8359-4506-bfb3-cf87aa8120ee"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--648f995e-9c3a-41e4-aeee-98bb41037426.json
+++ b/ics-attack/attack-pattern/attack-pattern--648f995e-9c3a-41e4-aeee-98bb41037426.json
@@ -46,7 +46,6 @@
                 "Mail server"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--648f995e-9c3a-41e4-aeee-98bb41037426"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--7374ab87-0782-41f8-b415-678c0950bb2a.json
+++ b/ics-attack/attack-pattern/attack-pattern--7374ab87-0782-41f8-b415-678c0950bb2a.json
@@ -39,7 +39,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--7374ab87-0782-41f8-b415-678c0950bb2a"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--7830cfcf-b268-4ac0-a69e-73c6affbae9a.json
+++ b/ics-attack/attack-pattern/attack-pattern--7830cfcf-b268-4ac0-a69e-73c6affbae9a.json
@@ -42,7 +42,6 @@
                 "Network intrusion detection system"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--7830cfcf-b268-4ac0-a69e-73c6affbae9a"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--83ebd22f-b401-4d59-8219-2294172cf916.json
+++ b/ics-attack/attack-pattern/attack-pattern--83ebd22f-b401-4d59-8219-2294172cf916.json
@@ -54,7 +54,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--83ebd22f-b401-4d59-8219-2294172cf916"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--8535b71e-3c12-4258-a4ab-40257a1becc4.json
+++ b/ics-attack/attack-pattern/attack-pattern--8535b71e-3c12-4258-a4ab-40257a1becc4.json
@@ -49,7 +49,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8535b71e-3c12-4258-a4ab-40257a1becc4"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--85a45294-08f1-4539-bf00-7da08aa7b0ee.json
+++ b/ics-attack/attack-pattern/attack-pattern--85a45294-08f1-4539-bf00-7da08aa7b0ee.json
@@ -47,7 +47,6 @@
                 "File monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--85a45294-08f1-4539-bf00-7da08aa7b0ee"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--8bb4538f-f16f-49f0-a431-70b5444c7349.json
+++ b/ics-attack/attack-pattern/attack-pattern--8bb4538f-f16f-49f0-a431-70b5444c7349.json
@@ -45,7 +45,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8bb4538f-f16f-49f0-a431-70b5444c7349"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--8d2f3bab-507c-4424-b58b-edc977bd215c.json
+++ b/ics-attack/attack-pattern/attack-pattern--8d2f3bab-507c-4424-b58b-edc977bd215c.json
@@ -63,7 +63,6 @@
                 "Authentication logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8d2f3bab-507c-4424-b58b-edc977bd215c"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--8e7089d3-fba2-44f8-94a8-9a79c53920c4.json
+++ b/ics-attack/attack-pattern/attack-pattern--8e7089d3-fba2-44f8-94a8-9a79c53920c4.json
@@ -40,7 +40,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8e7089d3-fba2-44f8-94a8-9a79c53920c4"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--94f042ae-3033-4a8d-9ec3-26396533a541.json
+++ b/ics-attack/attack-pattern/attack-pattern--94f042ae-3033-4a8d-9ec3-26396533a541.json
@@ -34,7 +34,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--94f042ae-3033-4a8d-9ec3-26396533a541"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b.json
+++ b/ics-attack/attack-pattern/attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b.json
@@ -50,7 +50,6 @@
                 "Conrad Layne - GE Digital"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--9f947a1c-3860-48a8-8af0-a2dfa3efde03.json
+++ b/ics-attack/attack-pattern/attack-pattern--9f947a1c-3860-48a8-8af0-a2dfa3efde03.json
@@ -35,7 +35,6 @@
                 "Malware reverse engineering"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--9f947a1c-3860-48a8-8af0-a2dfa3efde03"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--a81696ef-c106-482c-8f80-59c30f2569fb.json
+++ b/ics-attack/attack-pattern/attack-pattern--a81696ef-c106-482c-8f80-59c30f2569fb.json
@@ -46,7 +46,6 @@
                 "Dragos Threat Intelligence"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--a81696ef-c106-482c-8f80-59c30f2569fb"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--a8cfd474-9358-464f-a169-9c6f099a8e8a.json
+++ b/ics-attack/attack-pattern/attack-pattern--a8cfd474-9358-464f-a169-9c6f099a8e8a.json
@@ -40,7 +40,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--a8cfd474-9358-464f-a169-9c6f099a8e8a"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--ab390887-afc0-4715-826d-b1b167d522ae.json
+++ b/ics-attack/attack-pattern/attack-pattern--ab390887-afc0-4715-826d-b1b167d522ae.json
@@ -45,7 +45,6 @@
                 "API monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ab390887-afc0-4715-826d-b1b167d522ae"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--abb0a255-eb9c-48d0-8f5c-874bb84c0e45.json
+++ b/ics-attack/attack-pattern/attack-pattern--abb0a255-eb9c-48d0-8f5c-874bb84c0e45.json
@@ -34,7 +34,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--abb0a255-eb9c-48d0-8f5c-874bb84c0e45"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7.json
+++ b/ics-attack/attack-pattern/attack-pattern--ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7.json
@@ -50,7 +50,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--b0628bfc-5376-4a38-9182-f324501cb4cf.json
+++ b/ics-attack/attack-pattern/attack-pattern--b0628bfc-5376-4a38-9182-f324501cb4cf.json
@@ -41,7 +41,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b0628bfc-5376-4a38-9182-f324501cb4cf"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--b14395bd-5419-4ef4-9bd8-696936f509bb.json
+++ b/ics-attack/attack-pattern/attack-pattern--b14395bd-5419-4ef4-9bd8-696936f509bb.json
@@ -50,7 +50,6 @@
                 "User"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b14395bd-5419-4ef4-9bd8-696936f509bb"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--b5b9bacb-97f2-4249-b804-47fd44de1f95.json
+++ b/ics-attack/attack-pattern/attack-pattern--b5b9bacb-97f2-4249-b804-47fd44de1f95.json
@@ -43,7 +43,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b5b9bacb-97f2-4249-b804-47fd44de1f95"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--b7e13ee8-182c-4f19-92a4-a88d7d855d54.json
+++ b/ics-attack/attack-pattern/attack-pattern--b7e13ee8-182c-4f19-92a4-a88d7d855d54.json
@@ -39,7 +39,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b7e13ee8-182c-4f19-92a4-a88d7d855d54"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--b9160e77-ea9e-4ba9-b1c8-53a3c466b13d.json
+++ b/ics-attack/attack-pattern/attack-pattern--b9160e77-ea9e-4ba9-b1c8-53a3c466b13d.json
@@ -52,7 +52,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b9160e77-ea9e-4ba9-b1c8-53a3c466b13d"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--ba203963-3182-41ac-af14-7e7ebc83cd61.json
+++ b/ics-attack/attack-pattern/attack-pattern--ba203963-3182-41ac-af14-7e7ebc83cd61.json
@@ -40,7 +40,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ba203963-3182-41ac-af14-7e7ebc83cd61"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--be69c571-d746-4b1f-bdd0-c0c9817e9068.json
+++ b/ics-attack/attack-pattern/attack-pattern--be69c571-d746-4b1f-bdd0-c0c9817e9068.json
@@ -48,7 +48,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--be69c571-d746-4b1f-bdd0-c0c9817e9068"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--c267bbee-bb59-47fe-85e0-3ed210337c21.json
+++ b/ics-attack/attack-pattern/attack-pattern--c267bbee-bb59-47fe-85e0-3ed210337c21.json
@@ -86,7 +86,6 @@
                 "Data loss prevention"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--c267bbee-bb59-47fe-85e0-3ed210337c21"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--c5e3cdbc-0387-4be9-8f83-ff5c0865f377.json
+++ b/ics-attack/attack-pattern/attack-pattern--c5e3cdbc-0387-4be9-8f83-ff5c0865f377.json
@@ -40,7 +40,6 @@
                 "File monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--c5e3cdbc-0387-4be9-8f83-ff5c0865f377"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101.json
+++ b/ics-attack/attack-pattern/attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101.json
@@ -54,7 +54,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--d5a69cfb-fc2a-46cb-99eb-74b236db5061.json
+++ b/ics-attack/attack-pattern/attack-pattern--d5a69cfb-fc2a-46cb-99eb-74b236db5061.json
@@ -45,7 +45,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d5a69cfb-fc2a-46cb-99eb-74b236db5061"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--d614a9cf-18eb-4800-81e4-ab8ddf0baa73.json
+++ b/ics-attack/attack-pattern/attack-pattern--d614a9cf-18eb-4800-81e4-ab8ddf0baa73.json
@@ -38,7 +38,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d614a9cf-18eb-4800-81e4-ab8ddf0baa73"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4.json
+++ b/ics-attack/attack-pattern/attack-pattern--d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4.json
@@ -46,7 +46,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e076cca8-2f08-45c9-aff7-ea5ac798b387.json
+++ b/ics-attack/attack-pattern/attack-pattern--e076cca8-2f08-45c9-aff7-ea5ac798b387.json
@@ -40,7 +40,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e076cca8-2f08-45c9-aff7-ea5ac798b387"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e0d74479-86d2-465d-bf36-903ebecef43e.json
+++ b/ics-attack/attack-pattern/attack-pattern--e0d74479-86d2-465d-bf36-903ebecef43e.json
@@ -51,7 +51,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e0d74479-86d2-465d-bf36-903ebecef43e"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e2994b6a-122b-4043-b654-7411c5198ec0.json
+++ b/ics-attack/attack-pattern/attack-pattern--e2994b6a-122b-4043-b654-7411c5198ec0.json
@@ -36,7 +36,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e2994b6a-122b-4043-b654-7411c5198ec0"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e33c7ecc-5a38-497f-beb2-a9a2049a4c20.json
+++ b/ics-attack/attack-pattern/attack-pattern--e33c7ecc-5a38-497f-beb2-a9a2049a4c20.json
@@ -43,7 +43,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e33c7ecc-5a38-497f-beb2-a9a2049a4c20"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e5de767e-f513-41cd-aa15-33f6ce5fbf92.json
+++ b/ics-attack/attack-pattern/attack-pattern--e5de767e-f513-41cd-aa15-33f6ce5fbf92.json
@@ -49,7 +49,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e5de767e-f513-41cd-aa15-33f6ce5fbf92"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07.json
+++ b/ics-attack/attack-pattern/attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07.json
@@ -37,7 +37,6 @@
                 "Matan Dobrushin - Otorio"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--e72425f8-9ae6-41d3-bfdb-e1b865e60722.json
+++ b/ics-attack/attack-pattern/attack-pattern--e72425f8-9ae6-41d3-bfdb-e1b865e60722.json
@@ -54,7 +54,6 @@
                 "Digital signatures"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e72425f8-9ae6-41d3-bfdb-e1b865e60722"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e.json
+++ b/ics-attack/attack-pattern/attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e.json
@@ -39,7 +39,6 @@
                 "API monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--ead7bd34-186e-4c79-9a4d-b65bcce6ed9d.json
+++ b/ics-attack/attack-pattern/attack-pattern--ead7bd34-186e-4c79-9a4d-b65bcce6ed9d.json
@@ -45,7 +45,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ead7bd34-186e-4c79-9a4d-b65bcce6ed9d"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707.json
+++ b/ics-attack/attack-pattern/attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707.json
@@ -49,7 +49,6 @@
                 "SYSTEM"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707"
         }
     ]

--- a/ics-attack/attack-pattern/attack-pattern--f8df6b57-14bc-425f-9a91-6f59f6799307.json
+++ b/ics-attack/attack-pattern/attack-pattern--f8df6b57-14bc-425f-9a91-6f59f6799307.json
@@ -47,7 +47,6 @@
                 "Authentication logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--f8df6b57-14bc-425f-9a91-6f59f6799307"
         }
     ]

--- a/ics-attack/ics-attack.json
+++ b/ics-attack/ics-attack.json
@@ -39,7 +39,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--19a71d1e-6334-4233-8260-b749cae37953"
         },
         {
@@ -89,7 +88,6 @@
                 "Jos Wetzels - Midnight Blue"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2900bbd8-308a-4274-b074-5b8bde8347bc"
         },
         {
@@ -125,7 +123,6 @@
                 "Process command-line parameters"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3de230d4-3e42-4041-b089-17e1128feded"
         },
         {
@@ -169,7 +166,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--008b8f56-6107-48be-aa9f-746f927dbb61"
         },
         {
@@ -215,7 +211,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3f1f4ccb-9be2-4ff8-8f69-dd972221169b"
         },
         {
@@ -251,7 +246,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1c478716-71d9-46a4-9a53-fa5d576adb60"
         },
         {
@@ -290,7 +284,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8e7089d3-fba2-44f8-94a8-9a79c53920c4"
         },
         {
@@ -329,7 +322,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--a8cfd474-9358-464f-a169-9c6f099a8e8a"
         },
         {
@@ -369,7 +361,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--24a9253e-8948-4c98-b751-8e2aee53127c"
         },
         {
@@ -406,7 +397,6 @@
                 "Matan Dobrushin - Otorio"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07"
         },
         {
@@ -452,7 +442,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4"
         },
         {
@@ -486,7 +475,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--abb0a255-eb9c-48d0-8f5c-874bb84c0e45"
         },
         {
@@ -540,7 +528,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--83ebd22f-b401-4d59-8219-2294172cf916"
         },
         {
@@ -585,7 +572,6 @@
                 "Matan Dobrushin - Otorio"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--493832d9-cea6-4b63-abe7-9a65a6473675"
         },
         {
@@ -625,7 +611,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--50d3222f-7550-4a3c-94e1-78cb6c81d064"
         },
         {
@@ -664,7 +649,6 @@
                 "Third-party application logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3405891b-16aa-4bd7-bd7c-733501f9b20f"
         },
         {
@@ -709,7 +693,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8bb4538f-f16f-49f0-a431-70b5444c7349"
         },
         {
@@ -752,7 +735,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e33c7ecc-5a38-497f-beb2-a9a2049a4c20"
         },
         {
@@ -815,7 +797,6 @@
                 "Sequential Event Recorder"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1b22b676-9347-4c55-9a35-ef0dc653db5b"
         },
         {
@@ -858,7 +839,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--56ddc820-6cfb-407f-850b-52c035d123ac"
         },
         {
@@ -892,7 +872,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a"
         },
         {
@@ -926,7 +905,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--94f042ae-3033-4a8d-9ec3-26396533a541"
         },
         {
@@ -972,7 +950,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9"
         },
         {
@@ -1014,7 +991,6 @@
                 "Network intrusion detection system"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--7830cfcf-b268-4ac0-a69e-73c6affbae9a"
         },
         {
@@ -1052,7 +1028,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d614a9cf-18eb-4800-81e4-ab8ddf0baa73"
         },
         {
@@ -1087,7 +1062,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5a2610f6-9fff-41e1-bc27-575ca20383d4"
         },
         {
@@ -1127,7 +1101,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--32632a95-6856-47b9-9ab7-fea5cd7dce00"
         },
         {
@@ -1162,7 +1135,6 @@
                 "Malware reverse engineering"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--9f947a1c-3860-48a8-8af0-a2dfa3efde03"
         },
         {
@@ -1209,7 +1181,6 @@
                 "File monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--85a45294-08f1-4539-bf00-7da08aa7b0ee"
         },
         {
@@ -1272,7 +1243,6 @@
                 "Authentication logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8d2f3bab-507c-4424-b58b-edc977bd215c"
         },
         {
@@ -1313,7 +1283,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b0628bfc-5376-4a38-9182-f324501cb4cf"
         },
         {
@@ -1358,7 +1327,6 @@
                 "API monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ab390887-afc0-4715-826d-b1b167d522ae"
         },
         {
@@ -1396,7 +1364,6 @@
                 "Controller program"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--53a48c74-0025-45f4-b04a-baa853df8204"
         },
         {
@@ -1432,7 +1399,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e2994b6a-122b-4043-b654-7411c5198ec0"
         },
         {
@@ -1470,7 +1436,6 @@
                 "Windows event logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--53a26eee-1080-4d17-9762-2027d5a1b805"
         },
         {
@@ -1517,7 +1482,6 @@
                 "Authentication logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--f8df6b57-14bc-425f-9a91-6f59f6799307"
         },
         {
@@ -1556,7 +1520,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--7374ab87-0782-41f8-b415-678c0950bb2a"
         },
         {
@@ -1599,7 +1562,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b5b9bacb-97f2-4249-b804-47fd44de1f95"
         },
         {
@@ -1645,7 +1607,6 @@
                 "Dragos Threat Intelligence"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--a81696ef-c106-482c-8f80-59c30f2569fb"
         },
         {
@@ -1674,7 +1635,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--63b6942d-8359-4506-bfb3-cf87aa8120ee"
         },
         {
@@ -1737,7 +1697,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5fa00fdd-4a55-4191-94a0-564181d7fec2"
         },
         {
@@ -1782,7 +1741,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--138979ba-0430-4de6-a128-2fc0b056ba36"
         },
         {
@@ -1832,7 +1790,6 @@
                 "Conrad Layne - GE Digital"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b"
         },
         {
@@ -1871,7 +1828,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--36e9f5bc-ac13-4da4-a2f4-01f4877d9004"
         },
         {
@@ -1900,7 +1856,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1"
         },
         {
@@ -1945,7 +1900,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--4c2e1408-9d68-4187-8e6b-a77bc52700ec"
         },
         {
@@ -1985,7 +1939,6 @@
                 "Binary file metadata"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ba203963-3182-41ac-af14-7e7ebc83cd61"
         },
         {
@@ -2034,7 +1987,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e5de767e-f513-41cd-aa15-33f6ce5fbf92"
         },
         {
@@ -2085,7 +2037,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e0d74479-86d2-465d-bf36-903ebecef43e"
         },
         {
@@ -2129,7 +2080,6 @@
                 "Application logs"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722"
         },
         {
@@ -2178,7 +2128,6 @@
                 "SYSTEM"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707"
         },
         {
@@ -2222,7 +2171,6 @@
                 "Administrator"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2d0d40ad-22fa-4cc8-b264-072557e1364b"
         },
         {
@@ -2261,7 +2209,6 @@
                 "API monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e"
         },
         {
@@ -2295,7 +2242,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--539d0484-fe95-485a-b654-86991c0d0d00"
         },
         {
@@ -2336,7 +2282,6 @@
                 "Host network interfaces"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--38213338-1aab-479d-949b-c81b66ccca5c"
         },
         {
@@ -2381,7 +2326,6 @@
                 "Jos Wetzels - Midnight Blue"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--25852363-5968-4673-b81d-341d5ed90bd1"
         },
         {
@@ -2429,7 +2373,6 @@
                 "Joe Slowik - Dragos"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--be69c571-d746-4b1f-bdd0-c0c9817e9068"
         },
         {
@@ -2479,7 +2422,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7"
         },
         {
@@ -2516,7 +2458,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3067b85e-271e-4bc5-81ad-ab1a81d411e3"
         },
         {
@@ -2570,7 +2511,6 @@
                 "Digital signatures"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e72425f8-9ae6-41d3-bfdb-e1b865e60722"
         },
         {
@@ -2615,7 +2555,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--ead7bd34-186e-4c79-9a4d-b65bcce6ed9d"
         },
         {
@@ -2660,7 +2599,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--d5a69cfb-fc2a-46cb-99eb-74b236db5061"
         },
         {
@@ -2746,7 +2684,6 @@
                 "Data loss prevention"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--c267bbee-bb59-47fe-85e0-3ed210337c21"
         },
         {
@@ -2796,7 +2733,6 @@
                 "User"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b14395bd-5419-4ef4-9bd8-696936f509bb"
         },
         {
@@ -2833,7 +2769,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--23270e54-1d68-4c3b-b763-b25607bcef80"
         },
         {
@@ -2875,7 +2810,6 @@
                 "Controller program"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9"
         },
         {
@@ -2915,7 +2849,6 @@
                 "File monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--c5e3cdbc-0387-4be9-8f83-ff5c0865f377"
         },
         {
@@ -2950,7 +2883,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2dc2b567-8821-49f9-9045-8740f3d0b958"
         },
         {
@@ -2985,7 +2917,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5f3da2f3-91c8-4d8b-a02f-bf43a11def55"
         },
         {
@@ -3029,7 +2960,6 @@
                 "Windows Registry"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--063b5b92-5361-481a-9c3f-95492ed9a2d8"
         },
         {
@@ -3075,7 +3005,6 @@
                 "Mail server"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--648f995e-9c3a-41e4-aeee-98bb41037426"
         },
         {
@@ -3124,7 +3053,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--8535b71e-3c12-4258-a4ab-40257a1becc4"
         },
         {
@@ -3164,7 +3092,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--e076cca8-2f08-45c9-aff7-ea5ac798b387"
         },
         {
@@ -3209,7 +3136,6 @@
                 "Digital signatures"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--5e0f75da-e108-4688-a6de-a4f07cc2cbe3"
         },
         {
@@ -3261,7 +3187,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b9160e77-ea9e-4ba9-b1c8-53a3c466b13d"
         },
         {
@@ -3300,7 +3225,6 @@
             "created": "2020-05-21T17:43:26.506Z",
             "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--b7e13ee8-182c-4f19-92a4-a88d7d855d54"
         },
         {
@@ -3352,7 +3276,6 @@
                 "Network protocol analysis"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--40b300ba-f553-48bf-862e-9471b220d455"
         },
         {
@@ -3398,7 +3321,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2736b752-4ec5-4421-a230-8977dea7649c"
         },
         {
@@ -3439,7 +3361,6 @@
                 "Packet capture"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601"
         },
         {
@@ -3493,7 +3414,6 @@
                 "Process monitoring"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101"
         },
         {
@@ -3560,7 +3480,6 @@
                 "Scott Dougherty"
             ],
             "modified": "2020-05-21T17:43:26.506Z",
-            "type": "attack-pattern",
             "id": "attack-pattern--2877063e-1851-48d2-bcc6-bc1d2733157e"
         },
         {


### PR DESCRIPTION
There were duplicate `type` objects in each of the `attack-pattern` bundles and a handful of duplicate `x_mitre_platforms` objects. 