### PR TITLE
Update repo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CTI
 This repository contains the MITRE ATT&CK&reg; and CAPEC&trade; datasets expressed in STIX 2.0. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
 
-If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both MITRE/CTI (this repository) and attack-stix-data will be updated with new ATT&CK releases for the foreseeable future, but the data model of attack-stix-data will include quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
+If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both `MITRE/CTI` (this repository) and `attack-stix-data` will be maintained and updated with new ATT&CK releases for the foreseeable future, but the data model of `attack-stix-data` includes quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
 
 ## ATT&CK
 MITRE ATT&CK is a globally-accessible knowledge base of adversary tactics and techniques based on real-world observations. The ATT&CK knowledge base is used as a foundation for the development of specific threat models and methodologies in the private sector, in government, and in the cybersecurity product and service community.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CTI
-This repository contains the MITRE ATT&CK&reg; and CAPEC&trade; cataglogs expressed in STIX 2.0. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
+This repository contains the MITRE ATT&CK&reg; and CAPEC&trade; datasets expressed in STIX 2.0. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
 
-If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both MITRE/CTI (this repository) and attack-stix-data will be updated with new ATT&CK releases for the foreseeable future, but the data-model of attack-stix-data will include quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
+If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both MITRE/CTI (this repository) and attack-stix-data will be updated with new ATT&CK releases for the foreseeable future, but the data model of attack-stix-data will include quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
 
 ## ATT&CK
 MITRE ATT&CK is a globally-accessible knowledge base of adversary tactics and techniques based on real-world observations. The ATT&CK knowledge base is used as a foundation for the development of specific threat models and methodologies in the private sector, in government, and in the cybersecurity product and service community.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
-# cti
-The Cyber Threat Intelligence Repository of MITRE ATT&CK&reg; and CAPEC catalogs expressed in STIX 2.0 JSON. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
+# CTI
+This repository contains the MITRE ATT&CK&reg; and CAPEC&trade; cataglogs expressed in STIX 2.0. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
+
+If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both MITRE/CTI (this repository) and attack-stix-data will be updated with new ATT&CK releases for the foreseeable future, but the data-model of attack-stix-data will include quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
 
 ## ATT&CK
-ATT&CK is a catalog of techniques and tactics that describe post-compromise adversary behavior on typical enterprise IT environments. The core use cases involve using the catalog to analyze, triage, compare, describe, relate, and share post-compromise adversary behavior.
+MITRE ATT&CK is a globally-accessible knowledge base of adversary tactics and techniques based on real-world observations. The ATT&CK knowledge base is used as a foundation for the development of specific threat models and methodologies in the private sector, in government, and in the cybersecurity product and service community.
 
 https://attack.mitre.org
-
-## STIX
-Structured Threat Information Expression (STIX™) is a language and serialization format used to exchange cyber threat intelligence (CTI).
-
-STIX enables organizations to share CTI with one another in a consistent and machine readable manner, allowing security communities to better understand what computer-based attacks they are most likely to see and to anticipate and/or respond to those attacks faster and more effectively.
-
-STIX is designed to improve many different capabilities, such as collaborative threat analysis, automated threat exchange, automated detection and response, and more.
-
-https://oasis-open.github.io/cti-documentation/
 
 ## CAPEC
 
@@ -25,3 +18,12 @@ Understanding how the adversary operates is essential to effective cyber securit
  - Associated with Common Weakness Enumeration (CWE)
 
 https://capec.mitre.org/
+
+## STIX
+Structured Threat Information Expression (STIX™) is a language and serialization format used to exchange cyber threat intelligence (CTI).
+
+STIX enables organizations to share CTI with one another in a consistent and machine readable manner, allowing security communities to better understand what computer-based attacks they are most likely to see and to anticipate and/or respond to those attacks faster and more effectively.
+
+STIX is designed to improve many different capabilities, such as collaborative threat analysis, automated threat exchange, automated detection and response, and more.
+
+https://oasis-open.github.io/cti-documentation/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CTI
 This repository contains the MITRE ATT&CK&reg; and CAPEC&trade; datasets expressed in STIX 2.0. See [USAGE](USAGE.md) or [USAGE-CAPEC](USAGE-CAPEC.md) for information on using this content with [python-stix2](https://github.com/oasis-open/cti-python-stix2).
 
-If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both `MITRE/CTI` (this repository) and `attack-stix-data` will be maintained and updated with new ATT&CK releases for the foreseeable future, but the data model of `attack-stix-data` includes quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
+If you are looking for ATT&CK represented in STIX 2.1, please see the [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. Both MITRE/CTI (this repository) and attack-stix-data will be maintained and updated with new ATT&CK releases for the foreseeable future, but the data model of attack-stix-data includes quality-of-life improvements not found on MITRE/CTI. Please see the [attack-stix-data USAGE document](https://github.com/mitre-attack/attack-stix-data) for more information on the improved data model of that repository.
 
 ## ATT&CK
 MITRE ATT&CK is a globally-accessible knowledge base of adversary tactics and techniques based on real-world observations. The ATT&CK knowledge base is used as a foundation for the development of specific threat models and methodologies in the private sector, in government, and in the cybersecurity product and service community.

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,8 @@ This document describes how ATT&CK implements and extends the STIX format. To fi
 
 We also recommend reading the [ATT&CK Design and Philosophy Paper](https://attack.mitre.org/docs/ATTACK_Design_and_Philosophy_March_2020.pdf), which describes high-level overall approach, intention, and usage of ATT&CK.
 
+If you are looking for ATT&CK data represented in STIX 2.1, please see our [attack-stix-data](https://github.com/mitre-attack/attack-stix-data) GitHub repository. The accompanying [USAGE document](https://github.com/mitre-attack/attack-stix-data/blob/master/USAGE.md) includes more information on the improved data model of that repository.
+
 ## Table of Contents
 
 - [The ATT&CK data model](#the-attck-data-model)


### PR DESCRIPTION
Updates repository documentation:
- Add sinformation about ATT&CK in STIX 2.1 and links to [that repository](https://github.com/mitre-attack/attack-stix-data)
- Replaces old ATT&CK blurb with newer and more accurate ATT&CK blurb
- Moves STIX section to after the CAPEC section, since CAPEC is content on the repo and STIX is context for how it's represented
- Improvements to introductory paragraph for consistency with [attack-stix-data](https://github.com/mitre-attack/attack-stix-data)