### PR TITLE
Fix of the source name

### DIFF
--- a/ics-attack/attack-pattern/attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722.json
+++ b/ics-attack/attack-pattern/attack-pattern--097924ce-a9a9-4039-8591-e0deedfb8722.json
@@ -22,7 +22,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0836",
                     "url": "https://attack.mitre.org/techniques/T0836"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1.json
+++ b/ics-attack/attack-pattern/attack-pattern--1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1.json
@@ -19,7 +19,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0831",
                     "url": "https://attack.mitre.org/techniques/T0831"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601.json
+++ b/ics-attack/attack-pattern/attack-pattern--2883c520-7957-46ca-89bd-dab1ad53b601.json
@@ -20,7 +20,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0858",
                     "url": "https://attack.mitre.org/techniques/T0858"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a.json
+++ b/ics-attack/attack-pattern/attack-pattern--2aa406ed-81c3-4c1d-ba83-cfbee5a2847a.json
@@ -19,7 +19,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0868",
                     "url": "https://attack.mitre.org/techniques/T0868"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9.json
+++ b/ics-attack/attack-pattern/attack-pattern--3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9.json
@@ -19,7 +19,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0851",
                     "url": "https://attack.mitre.org/techniques/T0851"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--40b300ba-f553-48bf-862e-9471b220d455.json
+++ b/ics-attack/attack-pattern/attack-pattern--40b300ba-f553-48bf-862e-9471b220d455.json
@@ -19,7 +19,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0855",
                     "url": "https://attack.mitre.org/techniques/T0855"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b.json
+++ b/ics-attack/attack-pattern/attack-pattern--9a505987-ab05-4f46-a9a6-6441442eec3b.json
@@ -24,7 +24,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0830",
                     "url": "https://attack.mitre.org/techniques/T0830"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101.json
+++ b/ics-attack/attack-pattern/attack-pattern--cd2c76a4-5e23-4ca5-9c40-d5e0604f7101.json
@@ -25,7 +25,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0859",
                     "url": "https://attack.mitre.org/techniques/T0859"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07.json
+++ b/ics-attack/attack-pattern/attack-pattern--e6c31185-8040-4267-83d3-b217b8a92f07.json
@@ -26,7 +26,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0885",
                     "url": "https://attack.mitre.org/techniques/T0885"
                 }

--- a/ics-attack/attack-pattern/attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e.json
+++ b/ics-attack/attack-pattern/attack-pattern--ea0c980c-5cf0-43a7-a049-59c4c207566e.json
@@ -19,7 +19,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0840",
                     "url": "https://attack.mitre.org/techniques/T0840"
                 },

--- a/ics-attack/attack-pattern/attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707.json
+++ b/ics-attack/attack-pattern/attack-pattern--efbf7888-f61b-4572-9c80-7e2965c60707.json
@@ -20,7 +20,7 @@
             "x_mitre_version": "1.0",
             "external_references": [
                 {
-                    "source_name": "mitre-attack",
+                    "source_name": "mitre-ics-attack",
                     "external_id": "T0839",
                     "url": "https://attack.mitre.org/techniques/T0839"
                 },


### PR DESCRIPTION
Hi ATT&CK team,

I've noticed that in 11 attack patterns for ICS the `source_name` within the `external_references` is incorrect as it has the value `mitre-attack` instead of `mitre-ics-attack`.

Regards,
Marcus